### PR TITLE
Scroll to input text field even if input text field is not first responder after reload data

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -138,6 +138,8 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
     if (inputFieldShouldBecomeFirstResponder) {
         [self inputTextFieldBecomeFirstResponder];
+    } else {
+        [self focusInputTextField];
     }
 }
 
@@ -369,6 +371,14 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     self.inputTextField.placeholder = [self.tokens count] ? nil : self.placeholderText;
 }
 
+- (void)focusInputTextField
+{
+    CGPoint contentOffset = self.scrollView.contentOffset;
+    CGFloat targetY = self.inputTextField.y + [self heightForToken] - self.maxHeight;
+    if (targetY > contentOffset.y) {
+        [self.scrollView setContentOffset:CGPointMake(contentOffset.x, targetY) animated:NO];
+    }
+}
 
 #pragma mark - Data Source
 


### PR DESCRIPTION
This fixes an issue where the token field does not scroll to the last added token if the token field's `inputTextField` is not the first responder
