### PR TITLE
Truncate the end of long token titles

### DIFF
--- a/VENTokenField/VENToken.h
+++ b/VENTokenField/VENToken.h
@@ -28,6 +28,8 @@
 @property (copy, nonatomic) void (^didTapTokenBlock) (void);
 @property (strong, nonatomic) UIColor *colorScheme;
 
++ (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode;
+
 - (void)setTitleText:(NSString *)text;
 
 @end

--- a/VENTokenField/VENToken.m
+++ b/VENTokenField/VENToken.m
@@ -28,7 +28,14 @@
 @property (strong, nonatomic) IBOutlet UIView *backgroundView;
 @end
 
+static NSLineBreakMode _lineBreakMode = NSLineBreakByTruncatingTail;
+
 @implementation VENToken
+
++ (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode
+{
+    _lineBreakMode = lineBreakMode;
+}
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -45,6 +52,7 @@
     self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapToken:)];
     self.colorScheme = [UIColor blueColor];
     self.titleLabel.textColor = self.colorScheme;
+    self.titleLabel.lineBreakMode = _lineBreakMode;
     [self addGestureRecognizer:self.tapGestureRecognizer];
 }
 

--- a/VENTokenField/VENToken.xib
+++ b/VENTokenField/VENToken.xib
@@ -17,7 +17,7 @@
                 </view>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Octo Cat" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="OfV-hv-jq4">
                     <rect key="frame" x="0.0" y="6" width="121" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15.5"/>
                     <color key="textColor" red="0.21568627450980393" green="0.58431372549019611" blue="0.82352941176470584" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>

--- a/VENTokenFieldSample/ViewController.m
+++ b/VENTokenFieldSample/ViewController.m
@@ -8,6 +8,7 @@
 
 #import "ViewController.h"
 #import "VENTokenField.h"
+#import "VENToken.h"
 
 @interface ViewController () <VENTokenFieldDelegate, VENTokenFieldDataSource>
 @property (weak, nonatomic) IBOutlet VENTokenField *tokenField;
@@ -19,6 +20,9 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    [VENToken setLineBreakMode:NSLineBreakByTruncatingMiddle];
+    
     self.names = [NSMutableArray array];
     self.tokenField.delegate = self;
     self.tokenField.dataSource = self;


### PR DESCRIPTION
By changing the autoresize rules on the token label, we can force the
label to appropriately size itself to the token title. Before, a
token’s label was sized to its content, meaning that if it was actually
longer than a line in the token field, it freely overflowed and was
clipped by the outer VENToken’s view. I also exposed the line break
mode for VENTokens as a whole, allowing a client application to change
the line break mode to one appropriate to their data (breaking in the
middle or beginning of the line, for example). Including this in a release
requires a minor version as it adds new API.
