### PR TITLE
Content rescaling on layout (orientation) change

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -191,6 +191,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 {
     [super layoutSubviews];
     self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.frame) - self.horizontalInset * 2, CGRectGetHeight(self.frame) - self.verticalInset * 2);
+    [self reloadData];
 }
 
 - (void)layoutScrollView


### PR DESCRIPTION
Hi, Thanks for the great work! :)

I just found if I rotate the device then the token field's scroll view content size not follows its frame change, which implies the inputTextField's width also not resized.
Do you know a more convenience method to fix this than my layoutSubviews override?

Cheers
