### PR TITLE
Remove deprecated prepare_pods Slather call

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,9 +9,3 @@ target "VENTokenFieldSampleTests" do
   pod 'KIF', '~> 3.0.4'
 end
 
-begin
-  require 'slather'
-rescue LoadError
-  puts 'Slather has been disabled (not installed).'
-end
-


### PR DESCRIPTION
This call has been deprecated as displayed in the log of `pod install`
