### PR TITLE
When token width exceeds scrollView width, instead of going to the next line, take the remaining available space

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -260,19 +260,26 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
         [token setTitleText:[NSString stringWithFormat:@"%@,", title]];
         [self.tokens addObject:token];
-
-        if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line
-            token.frame = CGRectMake(*currentX, *currentY, token.width, token.height);
-        } else {
+        
+        CGFloat tokenWidth = token.width;
+        if (tokenWidth > self.scrollView.contentSize.width) { // Token is wider than max width
+            // Take all of the remaining space
+            token.frame = CGRectMake(*currentX, *currentY, self.scrollView.contentSize.width - *currentX, token.height);
             *currentY += token.height;
             *currentX = 0;
-            CGFloat tokenWidth = token.width;
-            if (tokenWidth > self.scrollView.contentSize.width) { // token is wider than max width
-                tokenWidth = self.scrollView.contentSize.width;
+            
+        } else {
+            if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line
+                token.frame = CGRectMake(*currentX, *currentY, token.width, token.height);
             }
-            token.frame = CGRectMake(*currentX, *currentY, tokenWidth, token.height);
+            else { // Go to next line
+                *currentY += token.height;
+                *currentX = 0;
+                token.frame = CGRectMake(*currentX, *currentY, token.width, token.height);
+            }
+            *currentX += token.width + self.tokenPadding;
         }
-        *currentX += token.width + self.tokenPadding;
+        
         [self.scrollView addSubview:token];
     }
 }


### PR DESCRIPTION
When token width exceeds scrollView width, instead of going to the next line (which looks like a bug), take the remaining available space.

Basically, if you type a really really long text, observe that it will go to next line, although next line won't fit as well. So, instead of doing that, we should take up the remaining space.
