### PR TITLE
Accessibility label

### DIFF
--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -69,6 +69,7 @@
 @property (strong, nonatomic) UILabel *toLabel;
 
 @property (copy, nonatomic) NSString *placeholderText;
+@property (copy, nonatomic) NSString *inputTextFieldAccessibilityLabel;
 
 - (void)setColorScheme:(UIColor *)color;
 

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -117,6 +117,11 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     self.inputTextField.placeholder = _placeholderText;
 }
 
+-(void)setInputTextFieldAccessibilityLabel:(NSString *)inputTextFieldAccessibilityLabel {
+    _inputTextFieldAccessibilityLabel = inputTextFieldAccessibilityLabel;
+    self.inputTextField.accessibilityLabel = _inputTextFieldAccessibilityLabel;
+}
+
 - (void)setInputTextFieldTextColor:(UIColor *)inputTextFieldTextColor
 {
     _inputTextFieldTextColor = inputTextFieldTextColor;
@@ -379,7 +384,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         _inputTextField.tintColor = self.colorScheme;
         _inputTextField.delegate = self;
         _inputTextField.placeholder = self.placeholderText;
-        _inputTextField.accessibilityLabel = self.placeholderText;
+        _inputTextField.accessibilityLabel = self.inputTextFieldAccessibilityLabel ?: NSLocalizedString(@"To", nil);
         [_inputTextField addTarget:self action:@selector(inputTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     }
     return _inputTextField;


### PR DESCRIPTION
The accessibility label is always "To", which is usually fine when this field is used as it is in the example (for contacts of some kind). When used in other situations (entering tags for a photo, for example), that label doesn't make sense.

This PR adds a public property for the accessibility label on the input, and defaults back to the original "To" when it's not set.
