### PR TITLE
Respond to isFirstResponder

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -64,6 +64,10 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     [self setUpInit];
 }
 
+- (BOOL)isFirstResponder {
+	return [self.inputTextField isFirstResponder];
+}
+
 - (BOOL)becomeFirstResponder
 {
     [self layoutTokensAndInputWithFrameAdjustment:YES];


### PR DESCRIPTION
This allows clients to determine if the inputTextField is the first responder without having to dive into the inner workings of the VENTokenField.

I wasn't 100% sure whether we should call [super isFirstResponder] before asking the inputTextField so I left that out, though for completeness (future proofing?) we may want to ask super first. Nevertheless, this diff allows VENTokenField clients to determine the most common case, whether the text field is currently the first responder.