### PR TITLE
call super resignFirstResponder

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -73,6 +73,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 - (BOOL)resignFirstResponder
 {
+	[super resignFirstResponder];
     return [self.inputTextField resignFirstResponder];
 }
 


### PR DESCRIPTION
According to iOS documentation:
 If you override this method, you must call super (the superclass implementation) at some point in your code.

This silences a static analyzer warning:
./Pods/VENTokenField/VENTokenField/VENTokenField.m:77:1: The resignFirstResponder instance method in UIResponder subclass VENTokenField is missing a [super resignFirstResponder] call