### PR TITLE
Feature/copy menu controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This protocol allows you to provide info about what you want to present in the t
 
 Implement...
 * ```tokenField:titleForTokenAtIndex:``` to specify what the title for the token at a particular index should be.
+* ```tokenField:underlyingStringForTokenAtIndex:``` to specify what will be copied with the long press on the token at a particular index.
 * ```numberOfTokensInTokenField:``` to specify how many tokens you have.
 * ```tokenFieldCollapsedText:``` to specify what you want the token field to say in the collapsed state.
 

--- a/VENTokenField/VENToken.h
+++ b/VENTokenField/VENToken.h
@@ -29,5 +29,6 @@
 @property (strong, nonatomic) UIColor *colorScheme;
 
 - (void)setTitleText:(NSString *)text;
+- (void)setUnderlyingText:(NSString *)text;
 
 @end

--- a/VENTokenField/VENToken.h
+++ b/VENTokenField/VENToken.h
@@ -26,9 +26,10 @@
 
 @property (assign, nonatomic) BOOL highlighted;
 @property (copy, nonatomic) void (^didTapTokenBlock) (void);
+@property (copy, nonatomic) void (^didLongPressTokenBlock) (void);
 @property (strong, nonatomic) UIColor *colorScheme;
 
 - (void)setTitleText:(NSString *)text;
-- (void)setUnderlyingText:(NSString *)text;
+- (void)setUnderlyingString:(NSString *)string;
 
 @end

--- a/VENTokenField/VENToken.m
+++ b/VENTokenField/VENToken.m
@@ -26,6 +26,7 @@
 @property (strong, nonatomic) UITapGestureRecognizer *tapGestureRecognizer;
 @property (strong, nonatomic) IBOutlet UILabel *titleLabel;
 @property (strong, nonatomic) IBOutlet UIView *backgroundView;
+@property (strong, nonatomic) NSString *underlyingText;
 @end
 
 @implementation VENToken
@@ -55,6 +56,11 @@
     [self.titleLabel sizeToFit];
     self.frame = CGRectMake(CGRectGetMinX(self.frame), CGRectGetMinY(self.frame), CGRectGetMaxX(self.titleLabel.frame) + 3, CGRectGetHeight(self.frame));
     [self.titleLabel sizeToFit];
+}
+
+- (void)setUnderlyingText:(NSString *)text
+{
+    self.underlyingText = text;
 }
 
 - (void)setHighlighted:(BOOL)highlighted

--- a/VENTokenField/VENToken.m
+++ b/VENTokenField/VENToken.m
@@ -24,6 +24,7 @@
 
 @interface VENToken ()
 @property (strong, nonatomic) UITapGestureRecognizer *tapGestureRecognizer;
+@property (strong, nonatomic) UILongPressGestureRecognizer *longPressGestureRecognizer;
 @property (strong, nonatomic) IBOutlet UILabel *titleLabel;
 @property (strong, nonatomic) IBOutlet UIView *backgroundView;
 @property (strong, nonatomic) NSString *underlyingText;
@@ -44,9 +45,11 @@
 {
     self.backgroundView.layer.cornerRadius = 5;
     self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapToken:)];
+    self.longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPressToken:)];
     self.colorScheme = [UIColor blueColor];
     self.titleLabel.textColor = self.colorScheme;
     [self addGestureRecognizer:self.tapGestureRecognizer];
+    [self addGestureRecognizer:self.longPressGestureRecognizer];
 }
 
 - (void)setTitleText:(NSString *)text
@@ -58,9 +61,9 @@
     [self.titleLabel sizeToFit];
 }
 
-- (void)setUnderlyingText:(NSString *)text
+- (void)setUnderlyingString:(NSString *)string
 {
-    self.underlyingText = text;
+    self.underlyingText = string;
 }
 
 - (void)setHighlighted:(BOOL)highlighted
@@ -79,6 +82,22 @@
     [self setHighlighted:_highlighted];
 }
 
+#pragma mark - UIMenuController Actions
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+    return (action == @selector(copy:));
+}
+
+- (void)copy:(id)sender
+{
+    [[UIPasteboard generalPasteboard] setString:self.underlyingText];
+}
 
 #pragma mark - Private
 
@@ -87,6 +106,18 @@
     if (self.didTapTokenBlock) {
         self.didTapTokenBlock();
     }
+}
+
+- (void)didLongPressToken:(UILongPressGestureRecognizer *)longPressGestureRecognizer
+{
+    if (self.didLongPressTokenBlock) {
+        self.didLongPressTokenBlock();
+        return;
+    }
+    [self becomeFirstResponder];
+    UIMenuController *menuController = [UIMenuController sharedMenuController];
+    [menuController setTargetRect:self.frame inView:self.superview];
+    [menuController setMenuVisible:YES animated:YES];
 }
 
 @end

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -34,6 +34,7 @@
 @protocol VENTokenFieldDataSource <NSObject>
 @optional
 - (NSString *)tokenField:(VENTokenField *)tokenField titleForTokenAtIndex:(NSUInteger)index;
+- (NSString *)tokenField:(VENTokenField *)tokenField underlyingStringForTokenAtIndex:(NSUInteger)index;
 - (NSUInteger)numberOfTokensInTokenField:(VENTokenField *)tokenField;
 - (NSString *)tokenFieldCollapsedText:(VENTokenField *)tokenField;
 @end

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -297,6 +297,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 {
     for (NSUInteger i = 0; i < [self numberOfTokens]; i++) {
         NSString *title = [self titleForTokenAtIndex:i];
+        NSString *underlyingString = [self underlyingStringForTokenAtIndex:i];
         VENToken *token = [[VENToken alloc] init];
         token.colorScheme = self.colorScheme;
 
@@ -307,6 +308,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         };
 
         [token setTitleText:[NSString stringWithFormat:@"%@,", title]];
+        [token setUnderlyingText:[NSString stringWithFormat:@"%@,", underlyingString]];
         [self.tokens addObject:token];
 
         if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -308,7 +308,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         };
 
         [token setTitleText:[NSString stringWithFormat:@"%@,", title]];
-        [token setUnderlyingText:[NSString stringWithFormat:@"%@,", underlyingString]];
+        [token setUnderlyingString:[NSString stringWithFormat:@"%@,", underlyingString]];
         [self.tokens addObject:token];
 
         if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -496,6 +496,14 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     return [NSString string];
 }
 
+- (NSString *)underlyingStringForTokenAtIndex:(NSUInteger)index
+{
+    if ([self.dataSource respondsToSelector:@selector(tokenField:underlyingStringForTokenAtIndex:)]) {
+        return [self.dataSource tokenField:self underlyingStringForTokenAtIndex:index];
+    }
+    return [NSString string];
+}
+
 - (NSUInteger)numberOfTokens
 {
     if ([self.dataSource respondsToSelector:@selector(numberOfTokensInTokenField:)]) {

--- a/VENTokenFieldSample/ViewController.m
+++ b/VENTokenFieldSample/ViewController.m
@@ -61,6 +61,11 @@
     return self.names[index];
 }
 
+- (NSString *)tokenField:(VENTokenField *)tokenField underlyingStringForTokenAtIndex:(NSUInteger)index
+{
+    return [NSString stringWithFormat:@"The name is: %@", self.names[index]];
+}
+
 - (NSUInteger)numberOfTokensInTokenField:(VENTokenField *)tokenField
 {
     return [self.names count];


### PR DESCRIPTION
This pull request provides the ability to copy the value from the selected token.

Full description:
When the user long presses the token a UIMenuController is shown with one action - copy. You can specify what exactly would be copied using the new method from the VENTokenFieldDataSource protocol. It is useful, for example, when your tokens represent contacts email-addresses, but the actual text is the contact's username.
Besides it, as we added the UILongPressGestureRecognizer to the VENToken, I decided to give the user opportunity to add its own longPressBlock, if for some reasons he doesn't want to use the menu controller functionality.
And, of course, I've updated the README file.