### PR TITLE
Fix for broken backspace behaviour in iOS8-8.2

### DIFF
--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -35,4 +35,22 @@
     return YES;
 }
 
+- (BOOL)keyboardInputShouldDelete:(UITextField *)textField {
+    BOOL shouldDelete = YES;
+    
+    if ([UITextField instancesRespondToSelector:_cmd]) {
+        BOOL (*keyboardInputShouldDelete)(id, SEL, UITextField *) = (BOOL (*)(id, SEL, UITextField *))[UITextField instanceMethodForSelector:_cmd];
+        
+        if (keyboardInputShouldDelete) {
+            shouldDelete = keyboardInputShouldDelete(self, _cmd, textField);
+        }
+    }
+    
+    if (![textField.text length] && [[[UIDevice currentDevice] systemVersion] intValue] >= 8) {
+        [self deleteBackward];
+    }
+    
+    return shouldDelete;
+}
+
 @end


### PR DESCRIPTION
In iOS8 versions prior to iOS8.3 backspace button was not deleting tokens. This behaviour is a known iOS8 bug and this commit is a workaround that fixes it. Credits for this solution goes to stackoverflow user cnotethegr8 (http://stackoverflow.com/users/278629/cnotethegr8), it's originally posted here: http://stackoverflow.com/a/25862878/2189481.

Reportedly this bug is now fixed in latest iOS8 version, that is in iOS8.3 and code reflects that.