### PR TITLE
Center tokens.

### DIFF
--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -24,15 +24,12 @@
 
 @implementation VENBackspaceTextField
 
-- (BOOL)keyboardInputShouldDelete:(UITextField *)textField
-{
+- (void)deleteBackward {
     if (self.text.length == 0) {
         if ([self.backspaceDelegate respondsToSelector:@selector(textFieldDidEnterBackspace:)]) {
             [self.backspaceDelegate textFieldDidEnterBackspace:self];
         }
     }
-
-    return YES;
 }
 
 @end

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -40,9 +40,9 @@
 @end
 
 typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
-    VENTokenFieldAlignmentLeft = 0,
-    VENTokenFieldAlignmentCenter,
-    VENTokenFieldAlignmentRight
+    VENTokenFieldAlignmentLeft = NSTextAlignmentLeft,
+    VENTokenFieldAlignmentCenter = NSTextAlignmentCenter,
+    VENTokenFieldAlignmentRight = NSTextAlignmentRight
 };
 
 

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
 @property (assign, nonatomic) CGFloat tokenPadding;
 @property (assign, nonatomic) CGFloat minInputWidth DEPRECATED_ATTRIBUTE;
 
-@property (assign, nonatomic) VENTokenFieldAlignment alignment;
+@property (assign, nonatomic) VENTokenFieldAlignment tokenAlignment;
 @property (assign, nonatomic) UIKeyboardType inputTextFieldKeyboardType;
 @property (assign, nonatomic) UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) UITextAutocapitalizationType autocapitalizationType;

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -41,8 +41,7 @@
 
 typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
     VENTokenFieldAlignmentLeft = NSTextAlignmentLeft,
-    VENTokenFieldAlignmentCenter = NSTextAlignmentCenter,
-    VENTokenFieldAlignmentRight = NSTextAlignmentRight
+    VENTokenFieldAlignmentCenter = NSTextAlignmentCenter
 };
 
 

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -64,7 +64,6 @@ typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
 @property (assign, nonatomic) CGFloat verticalInset;
 @property (assign, nonatomic) CGFloat horizontalInset;
 @property (assign, nonatomic) CGFloat tokenPadding;
-@property (assign, nonatomic) CGFloat minInputWidth;
 
 @property (assign, nonatomic) VENTokenFieldAlignment alignment;
 @property (assign, nonatomic) UIKeyboardType inputTextFieldKeyboardType;

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -64,6 +64,7 @@ typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
 @property (assign, nonatomic) CGFloat verticalInset;
 @property (assign, nonatomic) CGFloat horizontalInset;
 @property (assign, nonatomic) CGFloat tokenPadding;
+@property (assign, nonatomic) CGFloat minInputWidth DEPRECATED_ATTRIBUTE;
 
 @property (assign, nonatomic) VENTokenFieldAlignment alignment;
 @property (assign, nonatomic) UIKeyboardType inputTextFieldKeyboardType;

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -39,6 +39,12 @@
 - (UIColor *)tokenField:(VENTokenField *)tokenField colorSchemeForTokenAtIndex:(NSUInteger)index;
 @end
 
+typedef NS_ENUM(NSInteger, VENTokenFieldAlignment) {
+    VENTokenFieldAlignmentLeft = 0,
+    VENTokenFieldAlignmentCenter,
+    VENTokenFieldAlignmentRight
+};
+
 
 @interface VENTokenField : UIView
 
@@ -61,6 +67,7 @@
 @property (assign, nonatomic) CGFloat tokenPadding;
 @property (assign, nonatomic) CGFloat minInputWidth;
 
+@property (assign, nonatomic) VENTokenFieldAlignment alignment;
 @property (assign, nonatomic) UIKeyboardType inputTextFieldKeyboardType;
 @property (assign, nonatomic) UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) UITextAutocapitalizationType autocapitalizationType;

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -95,6 +95,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     self.colorScheme = [UIColor blueColor];
     self.toLabelTextColor = [UIColor colorWithRed:112/255.0f green:124/255.0f blue:124/255.0f alpha:1.0f];
     self.inputTextFieldTextColor = [UIColor colorWithRed:38/255.0f green:39/255.0f blue:41/255.0f alpha:1.0f];
+    self.alignment = VENTokenFieldAlignmentLeft;
     
     // Accessing bare value to avoid kicking off a premature layout run.
     _toLabelText = NSLocalizedString(@"To:", nil);
@@ -168,6 +169,11 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     return self.inputTextField.text;
 }
 
+- (void)setAlignment:(VENTokenFieldAlignment)alignment {
+    _alignment = alignment;
+    self.collapsedLabel.textAlignment = (NSTextAlignment)alignment;
+}
+
 
 #pragma mark - View Layout
 
@@ -191,6 +197,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     CGFloat currentX = 0;
     [self layoutToLabelInView:self origin:CGPointMake(self.horizontalInset, self.verticalInset) currentX:&currentX];
     [self layoutCollapsedLabelWithCurrentX:&currentX];
+    self.collapsedLabel.textAlignment = (NSTextAlignment)self.alignment;
 
     self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                         action:@selector(handleSingleTap:)];

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -577,7 +577,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
             default:
                 break;
         }
-        [self.scrollView addSubview:self.placeholderTextLabel];
+        [self.scrollView insertSubview:self.placeholderTextLabel belowSubview:self.inputTextField];
     } else {
         [self.placeholderTextLabel removeFromSuperview];
     }

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -312,38 +312,32 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         
         [self.tokens addObject:token];
 
-        if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line
-            token.frame = CGRectMake(*currentX, *currentY, token.width, token.height);
-        } else {
-            *currentY += token.height;
-            *currentX = 0;
-            CGFloat tokenWidth = token.width;
-            if (tokenWidth > self.scrollView.contentSize.width) { // token is wider than max width
-                tokenWidth = self.scrollView.contentSize.width;
-            }
-            token.frame = CGRectMake(*currentX, *currentY, tokenWidth, token.height);
-        }
+        token.frame = [self frameForToken:token currentX:currentX currentY:currentY];
         *currentX += token.width + self.tokenPadding;
         [self.scrollView addSubview:token];
     }
 
     VENToken *placeholderToken = [[VENToken alloc] init];
     [placeholderToken setTitleText:[self.inputTextFieldText stringByAppendingString:@"| "]]; // account for text field cursor and space
-    if (*currentX + placeholderToken.width <= self.scrollView.contentSize.width) { // token fits in current line
-        placeholderToken.frame = CGRectMake(*currentX, *currentY, placeholderToken.width, placeholderToken.height);
-    } else {
-        *currentY += placeholderToken.height;
-        *currentX = 0;
-        CGFloat tokenWidth = placeholderToken.width;
-        if (tokenWidth > self.scrollView.contentSize.width) { // token is wider than max width
-            tokenWidth = self.scrollView.contentSize.width;
-        }
-        placeholderToken.frame = CGRectMake(*currentX, *currentY, tokenWidth, placeholderToken.height);
-    }
+    placeholderToken.frame = [self frameForToken:placeholderToken currentX:currentX currentY:currentY];
 
     [self realignTokens:[self.tokens arrayByAddingObject:placeholderToken]
                currentX:currentX
               alignment:self.tokenAlignment];
+}
+
+- (CGRect)frameForToken:(VENToken *)token currentX:(CGFloat *)currentX currentY:(CGFloat *)currentY {
+    if (*currentX + token.width <= self.scrollView.contentSize.width) { // token fits in current line
+        return CGRectMake(*currentX, *currentY, token.width, token.height);
+    } else {
+        *currentY += token.height;
+        *currentX = 0;
+        CGFloat tokenWidth = token.width;
+        if (tokenWidth > self.scrollView.contentSize.width) { // token is wider than max width
+            tokenWidth = self.scrollView.contentSize.width;
+        }
+        return CGRectMake(*currentX, *currentY, tokenWidth, token.height);
+    }
 }
 
 - (void)realignTokens:(NSArray *)tokens
@@ -455,6 +449,9 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         _placeholderTextLabel.font = self.inputTextField.font;
         _placeholderTextLabel.textAlignment = (NSTextAlignment)self.tokenAlignment;
         _placeholderTextLabel.textColor = [UIColor colorWithWhite:.8 alpha:1];
+        [_placeholderTextLabel addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self.inputTextField
+                                                                                            action:@selector(becomeFirstResponder)]];
+        _placeholderTextLabel.userInteractionEnabled = YES;
     }
     return _placeholderTextLabel;
 }

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -372,10 +372,6 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     }
     CGFloat frameAdjustment = 0;
     switch (self.alignment) {
-        case VENTokenFieldAlignmentRight: {
-            frameAdjustment = self.scrollView.contentSize.width - firstToken.x - totalLineWidth;
-            break;
-        }
         case VENTokenFieldAlignmentCenter: {
             frameAdjustment = (self.scrollView.contentSize.width - firstToken.x - totalLineWidth) / 2.0;
             break;
@@ -388,6 +384,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     }
     if (firstToken.y >= *currentY) {
         *currentX = lastToken.x + lastToken.width;
+        *currentY = lastToken.y;
     }
 }
 

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -30,7 +30,6 @@ static const CGFloat VENTokenFieldDefaultVerticalInset      = 7.0;
 static const CGFloat VENTokenFieldDefaultHorizontalInset    = 15.0;
 static const CGFloat VENTokenFieldDefaultToLabelPadding     = 5.0;
 static const CGFloat VENTokenFieldDefaultTokenPadding       = 2.0;
-static const CGFloat VENTokenFieldDefaultMinInputWidth      = 20.0;
 static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 
@@ -93,7 +92,6 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     self.verticalInset = VENTokenFieldDefaultVerticalInset;
     self.horizontalInset = VENTokenFieldDefaultHorizontalInset;
     self.tokenPadding = VENTokenFieldDefaultTokenPadding;
-    self.minInputWidth = VENTokenFieldDefaultMinInputWidth;
     self.colorScheme = [UIColor blueColor];
     self.toLabelTextColor = [UIColor colorWithRed:112/255.0f green:124/255.0f blue:124/255.0f alpha:1.0f];
     self.inputTextFieldTextColor = [UIColor colorWithRed:38/255.0f green:39/255.0f blue:41/255.0f alpha:1.0f];

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -95,7 +95,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     self.colorScheme = [UIColor blueColor];
     self.toLabelTextColor = [UIColor colorWithRed:112/255.0f green:124/255.0f blue:124/255.0f alpha:1.0f];
     self.inputTextFieldTextColor = [UIColor colorWithRed:38/255.0f green:39/255.0f blue:41/255.0f alpha:1.0f];
-    self.alignment = VENTokenFieldAlignmentLeft;
+    self.tokenAlignment = VENTokenFieldAlignmentLeft;
     
     // Accessing bare value to avoid kicking off a premature layout run.
     _toLabelText = NSLocalizedString(@"To:", nil);
@@ -170,9 +170,9 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     return self.inputTextField.text;
 }
 
-- (void)setAlignment:(VENTokenFieldAlignment)alignment
+- (void)setTokenAlignment:(VENTokenFieldAlignment)alignment
 {
-    _alignment = alignment;
+    _tokenAlignment = alignment;
     self.collapsedLabel.textAlignment = (NSTextAlignment)alignment;
     self.placeholderTextLabel.textAlignment = (NSTextAlignment)alignment;
 }
@@ -200,7 +200,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     CGFloat currentX = 0;
     [self layoutToLabelInView:self origin:CGPointMake(self.horizontalInset, self.verticalInset) currentX:&currentX];
     [self layoutCollapsedLabelWithCurrentX:&currentX];
-    self.collapsedLabel.textAlignment = (NSTextAlignment)self.alignment;
+    self.collapsedLabel.textAlignment = (NSTextAlignment)self.tokenAlignment;
 
     self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                         action:@selector(handleSingleTap:)];
@@ -343,7 +343,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
     [self realignTokens:[self.tokens arrayByAddingObject:placeholderToken]
                currentX:currentX
-              alignment:self.alignment];
+              alignment:self.tokenAlignment];
 }
 
 - (void)realignTokens:(NSArray *)tokens
@@ -385,7 +385,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         totalLineWidth += token.width;
     }
     CGFloat frameAdjustment = 0;
-    switch (self.alignment) {
+    switch (self.tokenAlignment) {
         case VENTokenFieldAlignmentCenter: {
             frameAdjustment = (self.scrollView.contentSize.width - firstToken.x - totalLineWidth) / 2.0;
             break;
@@ -453,7 +453,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         _placeholderTextLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 0,
                                                                           [self heightForToken])];
         _placeholderTextLabel.font = self.inputTextField.font;
-        _placeholderTextLabel.textAlignment = (NSTextAlignment)self.alignment;
+        _placeholderTextLabel.textAlignment = (NSTextAlignment)self.tokenAlignment;
         _placeholderTextLabel.textColor = [UIColor colorWithWhite:.8 alpha:1];
     }
     return _placeholderTextLabel;
@@ -565,7 +565,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 - (void)updatePlaceholderTextLabel
 {
     if (![self.tokens count] && self.inputTextFieldText.length == 0) {
-        switch (self.alignment) {
+        switch (self.tokenAlignment) {
             case VENTokenFieldAlignmentCenter:
                 self.placeholderTextLabel.centerX = self.inputTextField.x;
                 break;

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -565,6 +565,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         switch (self.tokenAlignment) {
             case VENTokenFieldAlignmentCenter:
                 self.placeholderTextLabel.centerX = self.inputTextField.x;
+                self.inputTextField.x = self.placeholderTextLabel.x;
                 break;
             case VENTokenFieldAlignmentLeft:
                 self.placeholderTextLabel.x = self.inputTextField.x;


### PR DESCRIPTION
Also deprecated `minInputWidth`.

When adding logic to center icons, I also modified the logic for positioning the `inputTextField`. Now, the text it contains is treated like a token. So, the `inputTextField` goes wherever the token positioning logic puts this placeholder token (whose `titleText` is the current text in the `inputTextField). Because the token locations are now refreshed every time the user inputs a character, the `tokenField` will now create new lines while the user types, eliminating the need for a `minInputWidth`. 

More frequent updating of the token locations is critical for centering to maintain the "centered" feel as illustrated by the gif below.

![tokenfield](https://cloud.githubusercontent.com/assets/1578586/7641165/beb181a0-fa3c-11e4-9a92-13a5eab6146c.gif)

Fix #66.