### PR TITLE
Turn pending text into a token before collapsing

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -110,6 +110,10 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 - (void)collapse
 {
+    VENBackspaceTextField *textField = [self inputTextField];
+    if ([textField.text length]) {
+        [self.delegate tokenField:self didEnterText:textField.text];
+    }
     [self layoutCollapsedLabel];
 }
 


### PR DESCRIPTION
Entering some text then tapping elsewhere on the interface should not lose the text.