### PR TITLE
Fixed issue #38 with custom keyboards

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -342,6 +342,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     [self.invisibleTextField setAutocorrectionType:self.autocorrectionType];
     [self.invisibleTextField setAutocapitalizationType:self.autocapitalizationType];
     self.invisibleTextField.delegate = self;
+    self.invisibleTextField.backspaceDelegate = self;
     [self addSubview:self.invisibleTextField];
 }
 
@@ -409,6 +410,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
         _inputTextField.autocapitalizationType = self.autocapitalizationType;
         _inputTextField.tintColor = self.colorScheme;
         _inputTextField.delegate = self;
+        _inputTextField.backspaceDelegate = self;
         _inputTextField.placeholder = self.placeholderText;
         _inputTextField.accessibilityLabel = self.inputTextFieldAccessibilityLabel ?: NSLocalizedString(@"To", nil);
         _inputTextField.inputAccessoryView = self.inputTextFieldAccessoryView;


### PR DESCRIPTION
The `VENBackspaceTextField` didn't call its delegate method `textFieldDidEnterBackspace` when using with custom keyboards on iOS 8+.
I have replaced this with custom checking of changes made to text in the `UITextField`'s delegate method `textField:shouldChangeCharactersInRange:replacementString`. For this to work I need to observe the `UITextField` delegate in both `inputTextField` and `invisibleTextField`.
