### PR TITLE
Delegate for return key when not completing token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Similar to ```UITableView```, ```VENTokenField``` provides two protocols: ```<VE
 ### VENTokenFieldDelegate
 This protocol notifies you when things happen in the token field that you might want to know about.
 
-* ```tokenField:didEnterText:``` is called when a user hits the return key on the input field.
+* ```tokenField:didEnterText:``` is called when a user hits the return key on the input field, completing a token.
 * ```tokenField:didDeleteTokenAtIndex:``` is called when a user deletes a token at a particular index.
 * ```tokenField:didChangeText:``` is called when a user changes the text in the input field.
 * ```tokenFieldDidBeginEditing:``` is called when the input field becomes first responder.
+* ```tokenFieldDidReturn:``` is called when the user hits the return key on the input field with no partial text entered.
 
 ### VENTokenFieldDataSource
 This protocol allows you to provide info about what you want to present in the token field.

--- a/VENTokenField/VENTokenField.h
+++ b/VENTokenField/VENTokenField.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)tokenField:(VENTokenField *)tokenField didChangeText:(nullable NSString *)text;
 - (void)tokenFieldDidBeginEditing:(VENTokenField *)tokenField;
 - (void)tokenField:(VENTokenField *)tokenField didChangeContentHeight:(CGFloat)height;
+- (void)tokenFieldDidReturn:(VENTokenField *)tokenField;
 @end
 
 @protocol VENTokenFieldDataSource <NSObject>

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -548,9 +548,13 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
 {
-    if ([self.delegate respondsToSelector:@selector(tokenField:didEnterText:)]) {
-        if ([textField.text length]) {
+    if ([textField.text length]) {
+        if ([self.delegate respondsToSelector:@selector(tokenField:didEnterText:)]) {
             [self.delegate tokenField:self didEnterText:textField.text];
+        }
+    } else {
+        if ([self.delegate respondsToSelector:@selector(tokenFieldDidReturn:)]) {
+            [self.delegate tokenFieldDidReturn:self];
         }
     }
     


### PR DESCRIPTION
When the user has the VENTokenField focused, and only has completed tokens, or no text at, tapping the return key now calls a new delegate method `tokenFieldDidReturn:`.

This is useful for the user to confirm entry of tokens, allowing the app to move focus to another text field or view.

`tokenField:didEnterText:` functionality has no change, and the code is written such that these two delegate methods are never called simultaneously.

I'm not at all certain that the naming of this delegate method is correct. Please feel free to suggest alternatives.
