### PR TITLE
Typing when token is selected now adds input text

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -342,6 +342,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     [self.invisibleTextField setAutocorrectionType:self.autocorrectionType];
     [self.invisibleTextField setAutocapitalizationType:self.autocapitalizationType];
     self.invisibleTextField.backspaceDelegate = self;
+    [self.invisibleTextField addTarget:self action:@selector(invisibleTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     [self addSubview:self.invisibleTextField];
 }
 
@@ -449,6 +450,14 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     if ([self.delegate respondsToSelector:@selector(tokenField:didChangeText:)]) {
         [self.delegate tokenField:self didChangeText:textField.text];
     }
+}
+
+- (void)invisibleTextFieldDidChange:(UITextField *)textField
+{
+    _inputTextField.text = [_inputTextField.text?:@"" stringByAppendingString:_invisibleTextField.text];
+    _invisibleTextField.text = nil;
+    [_inputTextField becomeFirstResponder];
+    [self inputTextFieldDidChange:_inputTextField];
 }
 
 - (void)handleSingleTap:(UITapGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
Before this change, when you type while a token is selected, it adds text to the invisibleTextField, with no user feedback.  If you type multiple characters, you have to delete those characters before the token is deleted.  Now if you type while a token is selected, it deselects the token and adds the text to the visible inputTextField.
