### PR TITLE
Call awakeFromNib on super

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -61,6 +61,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setUpInit];
 }
 


### PR DESCRIPTION
If you leave out the call to awakeOnNib on super it will generate a warning in Xcode 8.
